### PR TITLE
Update Python version in CI workflow to 3.12

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
This pull request updates the Python version used in the documentation build workflow to ensure compatibility with the latest language features and dependencies.

- Workflow update:
  * [`.github/workflows/build_docs.yml`](diffhunk://#diff-4dfe935b4852393622c2b414783d1d11e1a868fd8485709124d90208fa61ec8bL17-R17): Upgraded the `python-version` from 3.10 to 3.12 in the documentation build job.