### PR TITLE
Add GitHub Actions workflow for Docker build and push on release

### DIFF
--- a/.github/workflows/publish-docker-on-release.yml
+++ b/.github/workflows/publish-docker-on-release.yml
@@ -1,0 +1,63 @@
+name: Container Build and Push
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # <--- fetch tags and history (needed for release/tag detection)
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=release        # <--- include release events so release:published yields tags
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SKIP_DOCS=true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and publishing Docker images to the GitHub Container Registry when a new tag is pushed or a release is published. This streamlines the deployment process by ensuring that Docker images are consistently built and pushed on release events.

**CI/CD automation:**

* Added a `.github/workflows/publish-docker-on-release.yml` workflow that builds and pushes multi-platform Docker images to GitHub Container Registry (`ghcr.io`) on tag push or release publish events. The workflow handles metadata extraction, tagging (including semver and `latest`), and logs in using GitHub credentials.