### PR TITLE
Add Dependabot configuration for automatic version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "uv"
+   directory: "/"
+   schedule:
+     interval: weekly


### PR DESCRIPTION
This pull request introduces Dependabot configuration to the repository, enabling automated dependency updates for the project. Dependabot will now check for updates to packages managed by the "uv" ecosystem on a weekly schedule.

Dependency management:

* Added a `.github/dependabot.yml` configuration file to enable Dependabot for the "uv" package ecosystem, set to run updates weekly.