### PR TITLE
chore: Update CI for release-please compatibility and logo source

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  release:
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It is designed for reproducible genomic plots in scripts, notebooks, Quarto docs
 Use it when you want compact tracks for BigWig-like signals, BED/narrowPeak intervals, links, genes, and optional matrix/QuantNado data.
 
 <p align="center">
-  <img src="docs/images/Logo.jpeg" alt="PlotNado logo" width="220">
+  <img src="https://raw.githubusercontent.com/alsmith151/plotnado/main/docs/images/Logo.jpeg" alt="PlotNado logo" width="220">
 </p>
 
 <p align="center">


### PR DESCRIPTION
This pull request introduces updates to the GitHub Actions workflow and improves the image reference in the project documentation. The workflow changes enhance release automation, while the documentation change ensures the project logo displays correctly.

**GitHub Actions workflow improvements:**

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R7-R9): Added support for triggering the workflow on GitHub Releases (`release: types: [published]`) and manual dispatches (`workflow_dispatch`), making publishing more flexible and automatable.

**Documentation update:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8): Updated the logo image source to use an absolute URL, ensuring the logo displays correctly regardless of where the README is viewed.